### PR TITLE
Add fuction to get only local printers names

### DIFF
--- a/printer_test.go
+++ b/printer_test.go
@@ -54,3 +54,21 @@ func TestReadNames(t *testing.T) {
 	}
 	t.Fatal("Default printed %q is not listed amongst printers returned by ReadNames %q", name, names)
 }
+
+func TestReadLocalNames(t *testing.T) {
+	names, err := ReadLocalNames()
+	if err != nil {
+		t.Fatalf("ReadNames failed: %v", err)
+	}
+	name, err := Default()
+	if err != nil {
+		t.Fatalf("Default failed: %v", err)
+	}
+	// make sure default printer is listed
+	for _, v := range names {
+		if v == name {
+			return
+		}
+	}
+	t.Fatal("Default printed %q is not listed amongst printers returned by ReadNames %q", name, names)
+}


### PR DESCRIPTION
@odino @cirpo 

This PR add a new method `ReadLocalNames` that returns a list of printers mounted locally. Test are passing (you need to run them on windows :) )
